### PR TITLE
Add variables for the intermediate and final outputs to go to

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 #addin "Cake.Yaml"
 #addin "Newtonsoft.Json"
 var target = Argument("target", "virtualbox-local");
-var output_to = Argument("output_to", ".");
+var output_to = Argument("output-to", ".");
 var os = Argument("os","Windows2016StdCore");
 var atlas_username = Argument("atlas_username","MattHodge");
 var atlas_version = Argument("atlas_version","0.0.1");

--- a/build.cake
+++ b/build.cake
@@ -96,7 +96,7 @@ public ProcessSettings RunPacker(bool install_vbox_tools, OSToBuild os, string s
     source_path_var = "";
   }
 
-  string packer_cmd = String.Format("-var \"install_vbox_tools={0}\" -var \"os_name={1}\" -var \"iso_checksum={2}\" -var \"iso_url={3}\" -var \"guest_os_type={4}\" -var \"full_os_name={5}\" -var \"atlas_username={6}\" -var \"atlas_version={7}\" {8} {9}",
+  string packer_cmd = String.Format("-var-file=default-variable-values.json -var \"install_vbox_tools={0}\" -var \"os_name={1}\" -var \"iso_checksum={2}\" -var \"iso_url={3}\" -var \"guest_os_type={4}\" -var \"full_os_name={5}\" -var \"atlas_username={6}\" -var \"atlas_version={7}\" {8} {9}",
     vbox_tools,
     os.osName,
     os.isoChecksum,

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,7 @@
 #addin "Cake.Yaml"
 #addin "Newtonsoft.Json"
 var target = Argument("target", "virtualbox-local");
+var output_to = Argument("output_to", ".");
 var os = Argument("os","Windows2016StdCore");
 var atlas_username = Argument("atlas_username","MattHodge");
 var atlas_version = Argument("atlas_version","0.0.1");
@@ -60,18 +61,19 @@ public OSToBuild LoadYAMLConfig(string yaml_path, string os)
 }
 
 
-public string GetPackerSourcePath(string os_name, string source_path)
+public string GetPackerSourcePath(string os_name, string output_to, string source_path)
 {
     string source_path_var = String.Format(source_path,
       os_name
     );
+    source_path_var = output_to + "/" + source_path_var;
 
     Information("Source Path: " + source_path_var);
 
     return source_path_var;
 }
 
-public ProcessSettings RunPacker(bool install_vbox_tools, OSToBuild os, string source_path, string json_file_path, string atlas_username, string atlas_version)
+public ProcessSettings RunPacker(bool install_vbox_tools, OSToBuild os, string output_to, string source_path, string json_file_path, string atlas_username, string atlas_version)
 {
   string vbox_tools;
   string source_path_var;
@@ -88,7 +90,7 @@ public ProcessSettings RunPacker(bool install_vbox_tools, OSToBuild os, string s
   if (source_path != null)
   {
     source_path_var = String.Format(" -var \"source_path={0}\"",
-      GetPackerSourcePath(os.osName, source_path)
+      GetPackerSourcePath(os.osName, output_to, source_path)
     );
   }
   else
@@ -123,7 +125,7 @@ Task("virtualbox-01-windows-base")
   .Does(() =>
 {
     string jsonToBuild = String.Format("{0}/01-windows-base.json", virtualBoxBuilderPath);
-    StartProcess("packer", RunPacker(installVBoxTools, OSES, "", jsonToBuild, atlas_username, atlas_version));
+    StartProcess("packer", RunPacker(installVBoxTools, OSES, output_to, "", jsonToBuild, atlas_username, atlas_version));
 });
 
 Task("virtualbox-02-win_updates-wmf5")
@@ -131,7 +133,7 @@ Task("virtualbox-02-win_updates-wmf5")
   .Does(() =>
 {
     string jsonToBuild = String.Format("{0}/02-win_updates-wmf5.json", virtualBoxBuilderPath);
-    StartProcess("packer", RunPacker(installVBoxTools, OSES, "./output-{0}-base/{0}-base.ovf", jsonToBuild, atlas_username, atlas_version));
+    StartProcess("packer", RunPacker(installVBoxTools, OSES, output_to, "output-{0}-base/{0}-base.ovf", jsonToBuild, atlas_username, atlas_version));
 });
 
 Task("virtualbox-03-cleanup")
@@ -139,7 +141,7 @@ Task("virtualbox-03-cleanup")
   .Does(() =>
 {
     string jsonToBuild = String.Format("{0}/03-cleanup.json", virtualBoxBuilderPath);
-    StartProcess("packer", RunPacker(installVBoxTools, OSES, "./output-{0}-updates_wmf5/{0}-updates_wmf5.ovf", jsonToBuild, atlas_username, atlas_version));
+    StartProcess("packer", RunPacker(installVBoxTools, OSES, output_to, "output-{0}-updates_wmf5/{0}-updates_wmf5.ovf", jsonToBuild, atlas_username, atlas_version));
 });
 
 Task("virtualbox-local")
@@ -147,7 +149,7 @@ Task("virtualbox-local")
   .Does(() =>
 {
     string jsonToBuild = String.Format("{0}/04-local.json", virtualBoxBuilderPath);
-    StartProcess("packer", RunPacker(installVBoxTools, OSES, "./output-{0}-cleanup/{0}-cleanup.ovf", jsonToBuild, atlas_username, atlas_version));
+    StartProcess("packer", RunPacker(installVBoxTools, OSES, output_to, "output-{0}-cleanup/{0}-cleanup.ovf", jsonToBuild, atlas_username, atlas_version));
 });
 
 Task("virtualbox-atlas")
@@ -155,7 +157,7 @@ Task("virtualbox-atlas")
   .Does(() =>
 {
     string jsonToBuild = String.Format("{0}/04-atlas.json", virtualBoxBuilderPath);
-    StartProcess("packer", RunPacker(installVBoxTools, OSES, "./output-{0}-cleanup/{0}-cleanup.ovf", jsonToBuild, atlas_username, atlas_version));
+    StartProcess("packer", RunPacker(installVBoxTools, OSES, output_to, "output-{0}-cleanup/{0}-cleanup.ovf", jsonToBuild, atlas_username, atlas_version));
 });
 
 // Hyper-V Tasks
@@ -163,14 +165,14 @@ Task("hyperv-local")
   .Does(() =>
 {
     string jsonToBuild = String.Format("{0}/01-windows-local.json", hypervBuilderPath);
-    StartProcess("packer", RunPacker(installVBoxTools, OSES, "", jsonToBuild, atlas_username, atlas_version));
+    StartProcess("packer", RunPacker(installVBoxTools, OSES, output_to, "", jsonToBuild, atlas_username, atlas_version));
 });
 
 Task("hyperv-atlas")
   .Does(() =>
 {
     string jsonToBuild = String.Format("{0}/01-windows-atlas.json", hypervBuilderPath);
-    StartProcess("packer", RunPacker(installVBoxTools, OSES, "", jsonToBuild, atlas_username, atlas_version));
+    StartProcess("packer", RunPacker(installVBoxTools, OSES, output_to, "", jsonToBuild, atlas_username, atlas_version));
 });
 
 RunTarget(target);

--- a/build.ps1
+++ b/build.ps1
@@ -20,6 +20,8 @@ and execute your Cake build script with the parameters you provide.
 The build script to execute.
 .PARAMETER Target
 The build script target to run.
+.PARAMETER OutputDirectoryBasePath
+The output directory to put intermediate artifacts
 .PARAMETER Configuration
 The build configuration to use.
 .PARAMETER Verbosity
@@ -45,6 +47,7 @@ http://cakebuild.net
 Param(
     [string]$Script = "build.cake",
     [string]$Target = "virtualbox-local",
+    [string]$OutputDirectoryBasePath = ".",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
@@ -186,6 +189,11 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
+# Make sure the OutputDirectoryBasePath exists
+if (!(Test-Path $OutputDirectoryBasePath)) {
+    new-item $OutputDirectoryBasePath -type directory
+}
+
 if ($Target -like 'hyperv*')
 {
     # check if hyper-v installed
@@ -209,5 +217,5 @@ if ($Target -like 'hyperv*')
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -output_to=`"$OutputDirectoryBasePath`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE

--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,7 @@ and execute your Cake build script with the parameters you provide.
 The build script to execute.
 .PARAMETER Target
 The build script target to run.
-.PARAMETER OutputDirectoryBasePath
+.PARAMETER OutputTo
 The output directory to put intermediate artifacts
 .PARAMETER Configuration
 The build configuration to use.
@@ -47,7 +47,7 @@ http://cakebuild.net
 Param(
     [string]$Script = "build.cake",
     [string]$Target = "virtualbox-local",
-    [string]$OutputDirectoryBasePath = ".",
+    [string]$OutputTo = ".",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
@@ -189,9 +189,9 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
-# Make sure the OutputDirectoryBasePath exists
-if (!(Test-Path $OutputDirectoryBasePath)) {
-    new-item $OutputDirectoryBasePath -type directory
+# Make sure the OutputTo exists
+if (!(Test-Path $OutputTo)) {
+    new-item $OutputTo -type directory
 }
 
 if ($Target -like 'hyperv*')
@@ -217,5 +217,5 @@ if ($Target -like 'hyperv*')
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -output_to=`"$OutputDirectoryBasePath`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -output-to=`"$OutputTo`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ for i in "$@"; do
         -s|--script) SCRIPT="$2"; shift ;;
         -t|--target) TARGET="$2"; shift ;;
         -c|--configuration) CONFIGURATION="$2"; shift ;;
+        -o|--output-to) OUTPUT_TO="$2"; shift ;;
         -v|--verbosity) VERBOSITY="$2"; shift ;;
         -d|--dryrun) DRYRUN="-dryrun" ;;
         --version) SHOW_VERSION=true ;;
@@ -97,5 +98,5 @@ fi
 if $SHOW_VERSION; then
     exec mono "$CAKE_EXE" -version
 else
-    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET -output-to=$OUTPUT_TO $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 fi

--- a/builders/hyperv/01-windows-atlas.json
+++ b/builders/hyperv/01-windows-atlas.json
@@ -165,6 +165,6 @@
         "iso_checksum": "",
         "iso_url": "",
         "os_name": "",
-        "intermediate_output_directory_base": "."
+        "intermediate_output_directory_base": ""
     }
 }

--- a/builders/hyperv/01-windows-atlas.json
+++ b/builders/hyperv/01-windows-atlas.json
@@ -2,7 +2,7 @@
     "builders": [
         {
             "type": "hyperv-iso",
-            "output_directory": "./output-{{ user `os_name` }}-base-hyperv/",
+            "output_directory": "{{user `intermediate_output_directory_base`}}/output-{{ user `os_name` }}-base-hyperv/",
             "vm_name": "{{ user `os_name` }}-base",
             "iso_url": "{{ user `iso_url` }}",
             "iso_checksum": "{{ user `iso_checksum` }}",
@@ -164,6 +164,7 @@
         "install_vbox_tools": "",
         "iso_checksum": "",
         "iso_url": "",
-        "os_name": ""
+        "os_name": "",
+        "intermediate_output_directory_base": "."
     }
 }

--- a/builders/hyperv/01-windows-local.json
+++ b/builders/hyperv/01-windows-local.json
@@ -153,7 +153,7 @@
         "iso_url": "",
         "guest_os_type": "",
         "install_vbox_tools": "",
-        "intermediate_output_directory_base": ".",
-        "vagrant_box_output_directory": "."
+        "intermediate_output_directory_base": "",
+        "vagrant_box_output_directory": ""
     }
 }

--- a/builders/hyperv/01-windows-local.json
+++ b/builders/hyperv/01-windows-local.json
@@ -2,7 +2,7 @@
     "builders": [
         {
             "type": "hyperv-iso",
-            "output_directory": "./output-{{ user `os_name` }}-base-hyperv/",
+            "output_directory": "{{user `intermediate_output_directory_base`}}/output-{{ user `os_name` }}-base-hyperv/",
             "vm_name": "{{ user `os_name` }}-base",
             "iso_url": "{{ user `iso_url` }}",
             "iso_checksum": "{{ user `iso_checksum` }}",
@@ -142,7 +142,7 @@
             {
                 "type": "vagrant",
                 "keep_input_artifact": false,
-                "output": "{{user `os_name`}}-wmf5-nocm-{{.Provider}}.box",
+                "output": "{{user `vagrant_box_output_directory`}}/{{user `os_name`}}-wmf5-nocm-{{.Provider}}.box",
                 "vagrantfile_template": "vagrantfile-windows.template"
             }
         ]
@@ -152,6 +152,8 @@
         "iso_checksum": "",
         "iso_url": "",
         "guest_os_type": "",
-        "install_vbox_tools": ""
+        "install_vbox_tools": "",
+        "intermediate_output_directory_base": ".",
+        "vagrant_box_output_directory": "."
     }
 }

--- a/builders/virtualbox/01-windows-base.json
+++ b/builders/virtualbox/01-windows-base.json
@@ -60,6 +60,6 @@
     "iso_url": "",
     "guest_os_type": "",
     "install_vbox_tools": "",
-    "intermediate_output_directory_base": "."
+    "intermediate_output_directory_base": ""
   }
 }

--- a/builders/virtualbox/01-windows-base.json
+++ b/builders/virtualbox/01-windows-base.json
@@ -22,7 +22,7 @@
           "2"
         ]
       ],
-      "output_directory": "./output-{{ user `os_name` }}-base/",
+      "output_directory": "{{user `intermediate_output_directory_base`}}/output-{{ user `os_name` }}-base/",
       "vm_name": "{{ user `os_name` }}-base",
       "guest_additions_mode": "attach",
       "guest_os_type": "{{ user `guest_os_type` }}",
@@ -59,6 +59,7 @@
     "iso_checksum": "",
     "iso_url": "",
     "guest_os_type": "",
-    "install_vbox_tools": ""
+    "install_vbox_tools": "",
+    "intermediate_output_directory_base": "."
   }
 }

--- a/builders/virtualbox/02-win_updates-wmf5.json
+++ b/builders/virtualbox/02-win_updates-wmf5.json
@@ -30,7 +30,7 @@
             "winrm_timeout": "12h",
             "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
             "shutdown_timeout": "1h",
-            "output_directory": "./output-{{user `os_name`}}-{{ user `image_name`}}/",
+            "output_directory": "{{user `intermediate_output_directory_base`}}/output-{{user `os_name`}}-{{ user `image_name`}}/",
             "vm_name": "{{user `os_name`}}-{{ user `image_name`}}",
             "guest_additions_mode": "disable"
         }
@@ -139,6 +139,7 @@
         "os_name": "",
         "headless": "true",
         "source_path": "",
-        "image_name": "updates_wmf5"
+        "image_name": "updates_wmf5",
+        "intermediate_output_directory_base": "."
     }
 }

--- a/builders/virtualbox/02-win_updates-wmf5.json
+++ b/builders/virtualbox/02-win_updates-wmf5.json
@@ -140,6 +140,6 @@
         "headless": "true",
         "source_path": "",
         "image_name": "updates_wmf5",
-        "intermediate_output_directory_base": "."
+        "intermediate_output_directory_base": ""
     }
 }

--- a/builders/virtualbox/03-cleanup.json
+++ b/builders/virtualbox/03-cleanup.json
@@ -3,7 +3,8 @@
         "headless": "true",
         "image_name": "cleanup",
         "os_name": "",
-        "source_path": ""
+        "source_path": "",
+        "intermediate_output_directory_base": "."
     },
     "builders": [
         {
@@ -11,7 +12,7 @@
             "guest_additions_mode": "disable",
             "guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
             "headless": "{{ user `headless` }}",
-            "output_directory": "./output-{{ user `os_name` }}-{{ user `image_name` }}/",
+            "output_directory": "{{user `intermediate_output_directory_base`}}/output-{{ user `os_name` }}-{{ user `image_name` }}/",
             "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
             "shutdown_timeout": "1h",
             "source_path": "{{user `source_path`}}",

--- a/builders/virtualbox/03-cleanup.json
+++ b/builders/virtualbox/03-cleanup.json
@@ -4,7 +4,7 @@
         "image_name": "cleanup",
         "os_name": "",
         "source_path": "",
-        "intermediate_output_directory_base": "."
+        "intermediate_output_directory_base": ""
     },
     "builders": [
         {

--- a/builders/virtualbox/04-atlas.json
+++ b/builders/virtualbox/04-atlas.json
@@ -30,7 +30,7 @@
             "winrm_timeout": "12h",
             "shutdown_command": "C:/Windows/packer/PackerShutdown.bat",
             "shutdown_timeout": "1h",
-            "output_directory": "./output-{{user `os_name`}}-{{user `image_name`}}/",
+            "output_directory": "{{user `intermediate_output_directory_base`}}/output-{{user `os_name`}}-{{user `image_name`}}/",
             "vm_name": "{{user `os_name`}}-{{user `image_name`}}",
             "guest_additions_mode": "disable"
         }
@@ -67,6 +67,7 @@
         "headless": "true",
         "image_name": "atlas-upload",
         "os_name": "",
-        "source_path": ""
+        "source_path": "",
+        "intermediate_output_directory_base": "."
     }
 }

--- a/builders/virtualbox/04-atlas.json
+++ b/builders/virtualbox/04-atlas.json
@@ -68,6 +68,6 @@
         "image_name": "atlas-upload",
         "os_name": "",
         "source_path": "",
-        "intermediate_output_directory_base": "."
+        "intermediate_output_directory_base": ""
     }
 }

--- a/builders/virtualbox/04-local.json
+++ b/builders/virtualbox/04-local.json
@@ -30,7 +30,7 @@
             "winrm_timeout": "12h",
             "shutdown_command": "C:/Windows/packer/PackerShutdown.bat",
             "shutdown_timeout": "1h",
-            "output_directory": "./output-{{user `os_name`}}-{{user `image_name`}}/",
+            "output_directory": "{{user `intermediate_output_directory_base`}}/output-{{user `os_name`}}-{{user `image_name`}}/",
             "vm_name": "{{user `os_name`}}-{{user `image_name`}}",
             "guest_additions_mode": "disable"
         }
@@ -46,7 +46,7 @@
             {
                 "type": "vagrant",
                 "keep_input_artifact": false,
-                "output": "{{user `os_name`}}-wmf5-nocm-{{.Provider}}.box",
+                "output": "{{user `vagrant_box_output_directory`}}/{{user `os_name`}}-wmf5-nocm-{{.Provider}}.box",
                 "vagrantfile_template": "vagrantfile-windows.template"
             }
         ]
@@ -55,6 +55,8 @@
         "headless": "true",
         "os_name": "",
         "source_path": "",
-        "image_name": "pkg-vagrant"
+        "image_name": "pkg-vagrant",
+        "intermediate_output_directory_base": ".",
+        "vagrant_box_output_directory": "."
     }
 }

--- a/builders/virtualbox/04-local.json
+++ b/builders/virtualbox/04-local.json
@@ -56,7 +56,7 @@
         "os_name": "",
         "source_path": "",
         "image_name": "pkg-vagrant",
-        "intermediate_output_directory_base": ".",
-        "vagrant_box_output_directory": "."
+        "intermediate_output_directory_base": "",
+        "vagrant_box_output_directory": ""
     }
 }

--- a/default-variable-values.json
+++ b/default-variable-values.json
@@ -1,0 +1,9 @@
+{
+  "guest_os_type": "",
+  "install_vbox_tools": "",
+  "iso_checksum": "",
+  "iso_url": "",
+  "os_name": "",
+  "intermediate_output_directory_base": ".",
+  "vagrant_box_output_directory": "."
+}


### PR DESCRIPTION
I do builds on an external drive because it has more space; this enables that.

On Windows, use forward slashes for path separators in these variables. I use `d:/packer/output` and `d:/packer/vagrant`

It's necessary for the intermediate outputs to have a separate var from final post-processor outputs, because if `keep_input_artifacts` is set false, I've seen the whole directory been cleared, which includes the final output itself. So they have to be different places.

The order of where the `-var-file=default-variable-values.json` parameter appears is important, too - the subsequent `-var`s overwrite, and if it's at the end of the chain, it overwrites all the previous ones.

This is one of the changes I suggested from #9. I'm testing the virtualbox chain only.