### PR TITLE
Do Windows Updates via different means

### DIFF
--- a/scripts/install_windows_updates.ps1
+++ b/scripts/install_windows_updates.ps1
@@ -1,8 +1,7 @@
-$wuInstallExe = Join-Path "$($env:windir)\SYSTEM32" 'WUInstallAMD64.exe'
-
-if (!(Test-Path -Path $wuInstallExe))
-{
-    Invoke-WebRequest -UseBasicParsing -Uri 'https://dl.dropboxusercontent.com/u/727435/Tools/WUInstallAMD64.exe' -OutFile $wuInstallExe
+if (-not(get-command Get-WUList -ErrorAction Ignore)) {
+  choco install --yes pswindowsupdate
+} else {
+  write-output "PSWindowsUpdates already installed"
 }
-
-C:\WINDOWS\SYSTEM32\WUInstallAMD64.exe /install /autoaccepteula /silent
+Get-WUInstall -IgnoreUserInput -AcceptAll -Verbose
+Get-WURebootStatus


### PR DESCRIPTION
The previous dropbox utility gave a 404, so use PSWindowsUpdates instead.

See https://gallery.technet.microsoft.com/scriptcenter/2d191bcd-3308-4edd-9de2-88dff796b0bc for documentation. There're various options and parameters and so on.